### PR TITLE
introduce parameter disable_conntrack

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 ferm::manage_service: false
 ferm::manage_configfile: false
+ferm::disable_conntrack: false
 ferm::configfile: /etc/ferm.conf
 ferm::input_policy: DROP
 ferm::forward_policy: DROP

--- a/manifests/chain.pp
+++ b/manifests/chain.pp
@@ -1,8 +1,10 @@
 # defined resource which creates all rules for one chain
 # @param policy [Ferm::Policies] Set the default policy for a CHAIN
+# @param disable_conntrack [Boolean] disable/enable usage of conntrack
 # @param chain [Ferm::Chains] name of the chain that should be managed
 define ferm::chain (
   Ferm::Policies $policy,
+  Boolean $disable_conntrack,
   Ferm::Chains $chain = $name,
 ) {
 
@@ -14,7 +16,12 @@ define ferm::chain (
 
   concat::fragment{"${chain}-policy":
     target  => "/etc/ferm.d/chains/${chain}.conf",
-    content => epp("${module_name}/ferm_chain_header.conf.epp", {'policy' => $policy }),
+    content => epp(
+      "${module_name}/ferm_chain_header.conf.epp", {
+        'policy'            => $policy,
+        'disable_conntrack' => $disable_conntrack,
+      }
+    ),
     order   => '01',
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,12 +35,15 @@ class ferm::config {
   }
 
   ferm::chain{'INPUT':
-    policy => $ferm::input_policy,
+    policy            => $ferm::input_policy,
+    disable_conntrack => $ferm::disable_conntrack,
   }
   ferm::chain{'FORWARD':
-    policy => $ferm::forward_policy,
+    policy            => $ferm::forward_policy,
+    disable_conntrack => $ferm::disable_conntrack,
   }
   ferm::chain{'OUTPUT':
-    policy => $ferm::output_policy,
+    policy            => $ferm::output_policy,
+    disable_conntrack => $ferm::disable_conntrack,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,9 @@
 # @param configfile [Stdlib::Absolutepath] path to the config file
 #   Default value: /etc/ferm.conf
 #   Allowed values: Stdlib::Absolutepath
+# @param disable_conntrack [Boolean] disable/enable the generation of conntrack rules
+#   Default value: false
+#   Allowed values: (true|false)
 # @param forward_policy [Ferm::Policies] default policy for the FORWARD chain
 #   Default value: DROP
 #   Allowed values: (ACCEPT|DROP|REJECT)
@@ -32,6 +35,7 @@ class ferm (
   Boolean $manage_service,
   Boolean $manage_configfile,
   Stdlib::Absolutepath $configfile,
+  Boolean $disable_conntrack,
   Ferm::Policies $forward_policy,
   Ferm::Policies $output_policy,
   Ferm::Policies $input_policy,

--- a/spec/defines/chain_spec.rb
+++ b/spec/defines/chain_spec.rb
@@ -7,13 +7,38 @@ describe 'ferm::chain', type: :define do
         facts
       end
       let(:title) { 'INPUT' }
-      let(:params) { { policy: 'DROP' } }
 
       context 'default params creates INPUT chain' do
+        let :params do
+          {
+            policy: 'DROP',
+            disable_conntrack: false
+          }
+        end
+
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('INPUT-policy') }
+        it do
+          is_expected.to contain_concat__fragment('INPUT-policy'). \
+            with_content(%r{ESTABLISHED RELATED})
+        end
         it { is_expected.to contain_concat('/etc/ferm.d/chains/INPUT.conf') }
         it { is_expected.to contain_ferm__chain('INPUT') }
+      end
+
+      context 'without conntrack' do
+        let :params do
+          {
+            policy: 'DROP',
+            disable_conntrack: true
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_concat__fragment('INPUT-policy')
+          is_expected.not_to contain_concat__fragment('INPUT-policy'). \
+            with_content(%r{ESTABLISHED RELATED})
+        end
       end
     end
   end

--- a/templates/ferm_chain_header.conf.epp
+++ b/templates/ferm_chain_header.conf.epp
@@ -1,8 +1,11 @@
 <%- | Ferm::Policies $policy,
+      Boolean $disable_conntrack,
 | -%>
 # Default policy for this chain
 policy <%= $policy %>;
 
+<% unless $disable_conntrack { -%>
 # connection tracking
 mod state state INVALID DROP;
 mod state state (ESTABLISHED RELATED) ACCEPT;
+<% } -%>


### PR DESCRIPTION
Default value of 'disable_conntrack' is 'false'. Existing installations are not affected by this change.