### PR TITLE
Add `proto_options` to enable usage of icmp types

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ The desired policy. Allowed values are Enum['ACCEPT','DROP', 'REJECT']
 
 the protocol we would like to filter. Allowed values are Enum['icmp', 'tcp', 'udp']
 
+### `proto_options`
+
+The protocol options we would like to add.
+The following example will suppress the hostname in programs like `traceroute`:
+```yaml
+---
+ferm::rules:
+  'drop_output_traceroute':
+    chain: 'OUTPUT'
+    policy: 'DROP'
+    proto: 'icmp'
+    proto_options: 'icmp-type time-exceeded'
+```
+
 #### `comment`
 
 A comment that will be written into the file and into ip(6)tables

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -7,6 +7,7 @@ define ferm::rule (
   Optional[Variant[Integer,String]] $sport = undef,
   Optional[String] $saddr = undef,
   Optional[String] $daddr = undef,
+  Optional[String[1]] $proto_options = undef,
   Enum['absent','present'] $ensure = 'present',
 ){
   $proto_real = "proto ${proto}"
@@ -24,12 +25,16 @@ define ferm::rule (
     default => "saddr @ipfilter(${saddr})",
   }
   $daddr_real = $daddr ? {
-    undef =>  '',
+    undef   =>  '',
     default => "daddr @ipfilter(${daddr})"
+  }
+  $proto_options_real = $proto_options ? {
+    undef   =>  '',
+    default => $proto_options
   }
   $comment_real = "mod comment comment '${comment}'"
 
-  $rule = squeeze("${comment_real} ${proto_real} ${dport_real} ${sport_real} ${daddr_real} ${saddr_real} ${policy};", ' ')
+  $rule = squeeze("${comment_real} ${proto_real} ${proto_options_real} ${dport_real} ${sport_real} ${daddr_real} ${saddr_real} ${policy};", ' ')
   if $ensure == 'present' {
     concat::fragment{"${chain}-${name}":
       target  => "/etc/ferm.d/chains/${chain}.conf",


### PR DESCRIPTION
Adding `proto_options` covers use cases which require more protocol info than just `tcp`, `udp`, or `icmp`. The following example will suppress the hostname in programs like `traceroute`:
```yaml
---
ferm::rules:
  'drop_output_traceroute':
    chain: 'OUTPUT'
    policy: 'DROP'
    proto: 'icmp'
    proto_options: 'icmp-type time-exceeded'
```