### PR TITLE
permit to choose ipv4, ipv6 or both

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,7 +7,7 @@
 
 _Public Classes_
 
-* [`ferm`](#ferm): Class: ferm  This class manages ferm installation and rule generation on modern linux systems  class{'ferm':   manage_service =>  true, }
+* [`ferm`](#ferm): Class: ferm  This class manages ferm installation and rule generation on modern linux systems  class{'ferm':   manage_service => true,   ip_v
 
 _Private Classes_
 
@@ -29,12 +29,13 @@ Class: ferm
 This class manages ferm installation and rule generation on modern linux systems
 
 class{'ferm':
-  manage_service =>  true,
+  manage_service => true,
+  ip_versions    =>  ['ip6'],
 }
 
 #### Examples
 
-##### deploy ferm and start it
+##### deploy ferm and start it, on node with only ipv6 enabled
 
 ```puppet
 
@@ -131,6 +132,13 @@ Data type: `Boolean`
 Enable/Disable logging in the INPUT chain of packets to the kernel log, if no explicit chain matched
 Default value: false
 Allowed values: (true|false)
+
+##### `ip_versions`
+
+Data type: `Array[Enum['ip','ip6']]`
+
+Set list of versions of ip we want ot use.
+Default value: ['ip', 'ip6']
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,3 +10,6 @@ ferm::rules: {}
 ferm::input_log_dropped_packets: false
 ferm::forward_log_dropped_packets: false
 ferm::output_log_dropped_packets: false
+ferm::ip_versions:
+  - ip
+  - ip6

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,8 @@ class ferm::config {
   # this is a private class
   assert_private("You're not supposed to do that!")
 
+  $_ip = join($ferm::ip_versions, ' ')
+
   # copy static files to ferm
   # on a long term point of view, we want to package this
   file{'/etc/ferm.d':
@@ -29,7 +31,11 @@ class ferm::config {
 
     concat::fragment{'ferm.conf':
       target  => $ferm::configfile,
-      content => epp("${module_name}/ferm.conf.epp"),
+      content => epp(
+        "${module_name}/ferm.conf.epp", {
+          'ip' => $_ip,
+          }
+      ),
       order   => '50',
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,9 +2,10 @@
 #
 # This class manages ferm installation and rule generation on modern linux systems
 #
-# @example deploy ferm and start it
+# @example deploy ferm and start it, on node with only ipv6 enabled
 # class{'ferm':
-#   manage_service =>  true,
+#   manage_service => true,
+#   ip_versions    =>  ['ip6'],
 # }
 #
 # @param manage_service Disable/Enable the management of the ferm daemon
@@ -40,6 +41,8 @@
 # @param input_log_dropped_packets Enable/Disable logging in the INPUT chain of packets to the kernel log, if no explicit chain matched
 #   Default value: false
 #   Allowed values: (true|false)
+# @param ip_versions Set list of versions of ip we want ot use.
+#   Default value: ['ip', 'ip6']
 class ferm (
   Boolean $manage_service,
   Boolean $manage_configfile,
@@ -52,6 +55,7 @@ class ferm (
   Boolean $output_log_dropped_packets,
   Boolean $input_log_dropped_packets,
   Hash $rules,
+  Array[Enum['ip','ip6']] $ip_versions,
 ) {
   contain ferm::install
   contain ferm::config

--- a/templates/ferm.conf.epp
+++ b/templates/ferm.conf.epp
@@ -1,6 +1,7 @@
+<%- | String[1] $ip | -%>
 # End custom section
 
-domain (ip ip6) table filter {
+domain (<%= $ip %>) table filter {
   chain INPUT {
     interface lo ACCEPT;
     @include '/etc/ferm.d/chains/INPUT.conf';


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The current version, by default, set up rules for iptables v4 and v6 and it is impossible to modify this.
On host with only one version enabled, the service fail during start.

The PR add a new parameter that permits to choose the version we want to use.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
