### PR TITLE
Add RedHat init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The main class has the following parameters:
 
 [Boolean] disable/enable the management of the ferm default config
 
+#### `manage_initfile`
+
+[Boolean] disable/enable the management of the ferm init script for RedHat-based OS
+
 #### `configfile`
 
 [Stdlib::Absolutepath] path to the config file

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 ferm::manage_service: false
 ferm::manage_configfile: false
+ferm::manage_initfile: false
 ferm::disable_conntrack: false
 ferm::configfile: /etc/ferm.conf
 ferm::input_policy: DROP

--- a/files/ferm
+++ b/files/ferm
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# -----------------------------------------------------------------------------
+# ------------------------[ MANAGED BY PUPPET ]--------------------------------
+# -----------------------------------------------------------------------------
+#
+# ferm          Configure ferm firewall rules from /etc/ferm.conf
+#
+#               Inspired by Max Kellermann <max@duempel.org>
+#
+# Version:      $Revision: 001 $
+### BEGIN INIT INFO
+# Provides:          ferm
+# Required-Start:    $network $remote_fs
+# Required-Stop:     $network $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Starts ferm firewall configuration
+# short-description: ferm firewall configuration
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+FERM=/usr/sbin/ferm
+CONFIG=/etc/ferm.conf
+NAME=ferm
+DESC="firewall"
+
+test -x "${FERM}"   || exit 0
+test -f "${CONFIG}" || exit 0
+
+# shellcheck disable=SC1091
+[ -r /etc/sysconfig/ferm ] && . /etc/sysconfig/ferm
+
+umask 0077
+
+FAST=${FAST:-yes}
+OPTIONS="${OPTIONS}"
+
+set -e
+
+# shellcheck disable=SC2086
+configure_ferm() {
+    if [ "${FAST}" = "yes" ]; then
+        ${FERM} ${OPTIONS} ${CONFIG} || return ${?}
+    else
+        ${FERM} ${OPTIONS} --slow ${CONFIG} || return ${?}
+    fi
+}
+
+case "${1}" in
+    start|reload|restart|force-reload)
+        # shellcheck disable=SC2039
+        echo -n "${1}ing ${DESC}" "${NAME}"
+        configure_ferm && echo " ... ok." || echo "... failed!"
+        ;;
+    stop)
+        # shellcheck disable=SC2039
+        echo -n "stopping ${DESC}" "${NAME}"
+        OPTIONS="${OPTIONS} --flush"
+        configure_ferm && echo " ... ok." || echo "... failed!"
+        ;;
+    *)
+        N=/etc/init.d/${NAME}
+        echo "Usage: ${N} {start|stop|restart|reload|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,9 @@
 # @param manage_configfile Disable/Enable the management of the ferm default config
 #   Default value: false
 #   Allowed values: (true|false)
+# @param manage_initfile Disable/Enable the management of the ferm init script for RedHat-based OS
+#   Default value: false
+#   Allowed values: (true|false)
 # @param configfile Path to the config file
 #   Default value: /etc/ferm.conf
 #   Allowed values: Stdlib::Absolutepath
@@ -46,6 +49,7 @@
 class ferm (
   Boolean $manage_service,
   Boolean $manage_configfile,
+  Boolean $manage_initfile,
   Stdlib::Absolutepath $configfile,
   Boolean $disable_conntrack,
   Ferm::Policies $forward_policy,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,11 +9,13 @@ class ferm::install {
     ensure => 'latest',
   }
 
-  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '6') <= 0 {
-    file{'/etc/init.d/ferm':
-      ensure => 'present',
-      mode   => '0755',
-      source => "puppet:///modules/${module_name}/ferm",
+  if $ferm::manage_initfile {
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '6') <= 0 {
+      file{'/etc/init.d/ferm':
+        ensure => 'present',
+        mode   => '0755',
+        source => "puppet:///modules/${module_name}/ferm",
+      }
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,4 +8,12 @@ class ferm::install {
   package{'ferm':
     ensure => 'latest',
   }
+
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '6') <= 0 {
+    file{'/etc/init.d/ferm':
+      ensure => 'present',
+      mode   => '0755',
+      source => "puppet:///modules/${module_name}/ferm",
+    }
+  }
 }

--- a/spec/classes/ferm_spec.rb
+++ b/spec/classes/ferm_spec.rb
@@ -22,6 +22,9 @@ describe 'ferm' do
         it { is_expected.to contain_file('/etc/ferm.d/chains') }
         it { is_expected.not_to contain_service('ferm') }
         it { is_expected.not_to contain_file('/etc/ferm.conf') }
+        if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i <= 6
+          it { is_expected.not_to contain_file('/etc/init.d/ferm') }
+        end
       end
 
       context 'with managed service' do
@@ -49,6 +52,17 @@ describe 'ferm' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_concat__fragment('ferm_header.conf') }
         it { is_expected.to contain_concat__fragment('ferm.conf') }
+      end
+      context 'with managed initfile' do
+        let :params do
+          { manage_initfile: true }
+        end
+
+        if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i <= 6
+          it { is_expected.to contain_file('/etc/init.d/ferm') }
+        else
+          it { is_expected.not_to contain_file('/etc/init.d/ferm') }
+        end
       end
       context 'it creates chains' do
         it { is_expected.to contain_concat__fragment('FORWARD-policy') }


### PR DESCRIPTION
OS like CentOS 6 are missing an init script for ferm. This PR ...
- adds an init script inspired by Kellermann's script for Debian and
- adds a test for RedHat-like OS to contain this init script