### PR TITLE
Allow array for saddr and daddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,29 @@ You can collect them like this:
 Ferm::Rule <<| tag == 'allow_kafka_server2server' |>>
 ```
 
-You can also define rules in hiera:
+You can also define rules in Hiera. Make sure to use `alias()` as interpolation function, because `hiera()` will always return string.
 
 ```yaml
 ---
+subnet01: '123.123.123.0/24'
+subnet02: '123.123.124.0/24'
+subnet03:
+ - '123.123.125.0/24'
+ - '123.123.126.0/24'
+
+subnets:
+  - "%{alias('subnet01')}"
+  - "%{alias('subnet02')}"
+  - "%{alias('subnet03')}"
+  - 123.123.127.0/24
+
 ferm::rules:
   'allow_http_https':
     chain: 'INPUT'
     policy: 'ACCEPT'
     proto: 'tcp'
     dport: '(80 443)'
-    saddr: "%{hiera('some_other_hiera_key')}"
+    saddr: "%{alias('subnets')}"
 ```
 
 ferm::rules is a hash. configured for deep merge. Hiera will collect all

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can collect them like this:
 Ferm::Rule <<| tag == 'allow_kafka_server2server' |>>
 ```
 
-You can also define rules in Hiera. Make sure to use `alias()` as interpolation function, because `hiera()` will always return string.
+You can also define rules in Hiera. Make sure to use `alias()` as interpolation function, because `hiera()` will always return a string.
 
 ```yaml
 ---

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -20,7 +20,7 @@ describe 'ferm::rule', type: :define do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('INPUT-filter-ssh').with_content("mod comment comment 'filter-ssh' proto tcp dport 22 saddr @ipfilter(127.0.0.1) ACCEPT;\n") }
+        it { is_expected.to contain_concat__fragment('INPUT-filter-ssh').with_content("mod comment comment 'filter-ssh' proto tcp dport 22 saddr @ipfilter((127.0.0.1)) ACCEPT;\n") }
       end
       context 'with a specific interface' do
         let(:title) { 'filter-ssh' }
@@ -36,7 +36,7 @@ describe 'ferm::rule', type: :define do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('INPUT-eth0-filter-ssh').with_content("  mod comment comment 'filter-ssh' proto tcp dport 22 saddr @ipfilter(127.0.0.1) ACCEPT;\n") }
+        it { is_expected.to contain_concat__fragment('INPUT-eth0-filter-ssh').with_content("  mod comment comment 'filter-ssh' proto tcp dport 22 saddr @ipfilter((127.0.0.1)) ACCEPT;\n") }
         it { is_expected.to contain_concat__fragment('INPUT-eth0-aaa').with_content("interface eth0 {\n") }
         it { is_expected.to contain_concat__fragment('INPUT-eth0-zzz').with_content("}\n") }
       end
@@ -54,7 +54,7 @@ describe 'ferm::rule', type: :define do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('INPUT-eth0-filter-ssh').with_content("  mod comment comment 'filter-ssh' proto tcp dport 22 daddr @ipfilter(127.0.0.1 123.123.123.123 10.0.0.1 10.0.0.2) ACCEPT;\n") }
+        it { is_expected.to contain_concat__fragment('INPUT-eth0-filter-ssh').with_content("  mod comment comment 'filter-ssh' proto tcp dport 22 daddr @ipfilter((127.0.0.1 123.123.123.123 10.0.0.1 10.0.0.2)) ACCEPT;\n") }
         it { is_expected.to contain_concat__fragment('INPUT-eth0-aaa').with_content("interface eth0 {\n") }
         it { is_expected.to contain_concat__fragment('INPUT-eth0-zzz').with_content("}\n") }
       end

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -40,6 +40,24 @@ describe 'ferm::rule', type: :define do
         it { is_expected.to contain_concat__fragment('INPUT-eth0-aaa').with_content("interface eth0 {\n") }
         it { is_expected.to contain_concat__fragment('INPUT-eth0-zzz').with_content("}\n") }
       end
+      context 'with a specific interface using array for daddr' do
+        let(:title) { 'filter-ssh' }
+        let :params do
+          {
+            chain: 'INPUT',
+            policy: 'ACCEPT',
+            proto: 'tcp',
+            dport: '22',
+            daddr: ['127.0.0.1', '123.123.123.123', ['10.0.0.1', '10.0.0.2']],
+            interface: 'eth0'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('INPUT-eth0-filter-ssh').with_content("  mod comment comment 'filter-ssh' proto tcp dport 22 daddr @ipfilter(127.0.0.1 123.123.123.123 10.0.0.1 10.0.0.2) ACCEPT;\n") }
+        it { is_expected.to contain_concat__fragment('INPUT-eth0-aaa').with_content("interface eth0 {\n") }
+        it { is_expected.to contain_concat__fragment('INPUT-eth0-zzz').with_content("}\n") }
+      end
     end
   end
 end


### PR DESCRIPTION
Adds data type `Array` to `ferm::rule` for `saddr` and `daddr`. This makes configuration of subnets in Hiera more maintainable:

- before
     - _either_
   ``` 
   subnet01: '123.123.123.0/24'
   subnet02: '123.123.124.0/24'
   subnet03: '123.123.125.0/24'
   subnets: "%{hiera('subnet01')} ${hiera('subnet02')} %{hiera('subnet03')}"
   ```
    - _or_
   ```
   subnets: '123.123.123.0/24 123.123.124.0/24 123.123.125.0/24 123.123.126.0/24 123.123.127.0/24 ...`
   ```
      - changing anything in those strings isn't very diff-friendly

- now
```
subnet01: '123.123.123.0/24'
subnet02: '123.123.124.0/24'
subnet03: '123.123.125.0/24'

subnets:
  - %{hiera('subnet01')} 
  - %{hiera('subnet02')}
  - %{hiera('subnet03')}
  - 123.123.126.0/24 
  - 123.123.127.0/24 
```

todo:
- [x] add tests