### PR TITLE
remove FreeBSD from supported OS list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,14 +40,6 @@
       ]
     },
     {
-      "operatingsystem": "FreeBSD",
-      "operatingsystemrelease": [
-        "9",
-        "10",
-        "11"
-      ]
-    },
-    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",


### PR DESCRIPTION
This module only works on systems with a linux kernel and iptables.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
