### PR TITLE
[WIP] prepare stuff for configuring different tables

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,6 +1,6 @@
 # defined resource which creates a single rule in a specific chain
 # @param chain Configure the chain where we want to add the rule
-# @param policy Configure what we want to do with the packet (drop, accept, log...)
+# @param action Configure what we want to do with the packet (drop, accept, log...)
 # @param proto Which protocol do we want to match, typically UDP or TCP
 # @param comment A comment that will be added to the ferm config and to ip{,6}tables
 # @param dport The destination port, can be a range as string or a single port number as integer
@@ -10,9 +10,10 @@
 # @param proto_options Optional parameters that will be passed to the protocol (for example to match specific ICMP types)
 # @param interface an Optional interface where this rule should be applied
 # @param ensure Set the rule to present or absent
+# @param table Select the target table (filter/raw/mangle/nat)
 define ferm::rule (
   String[1] $chain,
-  Ferm::Policies $policy,
+  Ferm::Actions $action,
   Ferm::Protocols $proto,
   String $comment = $name,
   Optional[Variant[Stdlib::Port,String[1]]] $dport = undef,
@@ -22,6 +23,7 @@ define ferm::rule (
   Optional[String[1]] $proto_options = undef,
   Optional[String[1]] $interface = undef,
   Enum['absent','present'] $ensure = 'present',
+  Ferm::Tables $table = 'filter',
 ){
   $proto_real = "proto ${proto}"
 
@@ -63,7 +65,7 @@ define ferm::rule (
   }
   $comment_real = "mod comment comment '${comment}'"
 
-  $rule = squeeze("${comment_real} ${proto_real} ${proto_options_real} ${dport_real} ${sport_real} ${daddr_real} ${saddr_real} ${policy};", ' ')
+  $rule = squeeze("${comment_real} ${proto_real} ${proto_options_real} ${dport_real} ${sport_real} ${daddr_real} ${saddr_real} ${action};", ' ')
   if $ensure == 'present' {
     if $interface {
       unless defined(Concat::Fragment["${chain}-${interface}-aaa"]) {

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -16,7 +16,7 @@ describe 'ferm::rule', type: :define do
         let :params do
           {
             chain: 'INPUT',
-            policy: 'ACCEPT',
+            action: 'ACCEPT',
             proto: 'tcp',
             dport: '22',
             saddr: '127.0.0.1'
@@ -31,7 +31,7 @@ describe 'ferm::rule', type: :define do
         let :params do
           {
             chain: 'INPUT',
-            policy: 'ACCEPT',
+            action: 'ACCEPT',
             proto: 'tcp',
             dport: '22',
             saddr: '127.0.0.1',
@@ -49,7 +49,7 @@ describe 'ferm::rule', type: :define do
         let :params do
           {
             chain: 'INPUT',
-            policy: 'ACCEPT',
+            action: 'ACCEPT',
             proto: 'tcp',
             dport: '22',
             daddr: ['127.0.0.1', '123.123.123.123', ['10.0.0.1', '10.0.0.2']],

--- a/types/actions.pp
+++ b/types/actions.pp
@@ -1,0 +1,2 @@
+# @summary a list of allowed actions for a rule
+type Ferm::Actions = Enum['ACCEPT','DROP', 'REJECT', 'NOTRACK', 'LOG']

--- a/types/tables.pp
+++ b/types/tables.pp
@@ -1,0 +1,2 @@
+# @summary a list of available tables
+type Ferm::Tables = Enum['raw', 'mangle', 'nat', 'filter']


### PR DESCRIPTION
#### Pull Request (PR) description
!WIP!

Currently rules can only be configured in the `filter` table of ferm/iptables.
For some scenarios it can be required to configure rules in the `nat`, `mangle` or `raw` tables as certain operations can only be done is these tables respectively.
For reference see:
https://stuffphilwrites.com/wp-content/uploads/2016/11/FW-IDS-iptables-Flowchart-2016-11-18.png

This PR is intended to implement the missing functionality.

#### This Pull Request (PR) fixes the following issues

- allow configuring rules in other tables than `filter`
