### PR TITLE
allow using an array for $proto

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -412,7 +412,7 @@ Alias of `Enum['ACCEPT', 'DROP']`
 
 a list of allowed protocolls to match
 
-Alias of `Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all']`
+Alias of `Variant[Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all'], Array[Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all']]]`
 
 ### Ferm::Tables
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -73,8 +73,10 @@ define ferm::rule (
     Ferm::Chain <| chain == $action_temp and table == $table |> -> Ferm::Rule[$name]
   }
 
-
-  $proto_real = "proto ${proto}"
+  $proto_real = $proto ? {
+    Array  => "proto (${join($proto, ' ')})",
+    String => "proto ${proto}",
+  }
 
   $dport_real = $dport ? {
     undef   => '',

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -114,6 +114,25 @@ describe 'ferm::rule', type: :define do
         it { is_expected.to contain_concat__fragment('INPUT-eth0-zzz').with_content("}\n") }
       end
 
+      context 'without a specific interface using array for proto' do
+        let(:title) { 'filter-consul' }
+        let :params do
+          {
+            chain: 'INPUT',
+            action: 'ACCEPT',
+            proto: %w[tcp udp],
+            dport: '(8301 8302)',
+            saddr: '127.0.0.1'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('INPUT-filter-consul').with_content("mod comment comment 'filter-consul' proto (tcp udp) dport (8301 8302) saddr @ipfilter((127.0.0.1)) ACCEPT;\n") }
+        it { is_expected.to contain_concat__fragment('filter-INPUT-config-include') }
+        it { is_expected.to contain_concat__fragment('filter-FORWARD-config-include') }
+        it { is_expected.to contain_concat__fragment('filter-OUTPUT-config-include') }
+      end
+
       context 'with jumping to custom chains' do
         # create custom chain
         let(:pre_condition) do

--- a/types/protocols.pp
+++ b/types/protocols.pp
@@ -1,2 +1,5 @@
 # @summary a list of allowed protocolls to match
-type Ferm::Protocols = Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all']
+type Ferm::Protocols = Variant[
+  Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all'],
+  Array[Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all']],
+]


### PR DESCRIPTION
This enables defining ferm::rule with multiple protocols at once,
because using 'all' for $proto does not allow using $dport/$sport.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
