### PR TITLE
fix kernel incompatibilities

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -263,6 +263,15 @@ Allowed values: (filter|raw|mangle|nat) (see Ferm::Tables type)
 
 Default value: 'filter'
 
+##### `ip_versions`
+
+Data type: `Array[Enum['ip','ip6']]`
+
+Set list of versions of ip we want ot use.
+Default value: $ferm::ip_versions
+
+Default value: $ferm::ip_versions
+
 ### ferm::rule
 
 This defined resource manages a single rule in a specific chain

--- a/manifests/chain.pp
+++ b/manifests/chain.pp
@@ -18,12 +18,15 @@
 # @param table Select the target table (filter/raw/mangle/nat)
 #   Default value: 'filter'
 #   Allowed values: (filter|raw|mangle|nat) (see Ferm::Tables type)
+# @param ip_versions Set list of versions of ip we want ot use.
+#   Default value: $ferm::ip_versions
 define ferm::chain (
   Boolean $disable_conntrack,
   Boolean $log_dropped_packets,
-  String[1] $chain                 = $name,
-  Optional[Ferm::Policies] $policy = undef,
-  Ferm::Tables $table              = 'filter',
+  String[1] $chain                     = $name,
+  Optional[Ferm::Policies] $policy     = undef,
+  Ferm::Tables $table                  = 'filter',
+  Array[Enum['ip','ip6']] $ip_versions = $ferm::ip_versions,
 ) {
   # prevent unmanaged files due to new naming schema
   # keep the default "filter" chains in the original location
@@ -74,7 +77,7 @@ define ferm::chain (
     target  => $ferm::configfile,
     content => epp(
       "${module_name}/ferm-table-chain-config-include.epp", {
-        'ip'       => join($ferm::ip_versions, ' '),
+        'ip'       => join($ip_versions, ' '),
         'table'    => $table,
         'chain'    => $chain,
         'filename' => $filename,

--- a/spec/classes/ferm_spec.rb
+++ b/spec/classes/ferm_spec.rb
@@ -67,7 +67,11 @@ describe 'ferm' do
         it { is_expected.to contain_concat__fragment('raw-PREROUTING-config-include') }
         it { is_expected.to contain_concat__fragment('raw-OUTPUT-config-include') }
         it { is_expected.to contain_concat__fragment('nat-PREROUTING-config-include') }
-        it { is_expected.to contain_concat__fragment('nat-INPUT-config-include') }
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+          it { is_expected.to contain_concat__fragment('nat-INPUT-config-include') }
+        else
+          it { is_expected.not_to contain_concat__fragment('nat-INPUT-config-include') }
+        end
         it { is_expected.to contain_concat__fragment('nat-OUTPUT-config-include') }
         it { is_expected.to contain_concat__fragment('nat-POSTROUTING-config-include') }
         it { is_expected.to contain_concat__fragment('mangle-PREROUTING-config-include') }
@@ -91,7 +95,11 @@ describe 'ferm' do
         it { is_expected.to contain_concat__fragment('raw-PREROUTING-policy') }
         it { is_expected.to contain_concat__fragment('raw-OUTPUT-policy') }
         it { is_expected.to contain_concat__fragment('nat-PREROUTING-policy') }
-        it { is_expected.to contain_concat__fragment('nat-INPUT-policy') }
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+          it { is_expected.to contain_concat__fragment('nat-INPUT-policy') }
+        else
+          it { is_expected.not_to contain_concat__fragment('nat-INPUT-policy') }
+        end
         it { is_expected.to contain_concat__fragment('nat-OUTPUT-policy') }
         it { is_expected.to contain_concat__fragment('nat-POSTROUTING-policy') }
         it { is_expected.to contain_concat__fragment('mangle-PREROUTING-policy') }
@@ -106,7 +114,11 @@ describe 'ferm' do
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/raw-PREROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/raw-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-PREROUTING.conf') }
-          it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-INPUT.conf') }
+          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+            it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-INPUT.conf') }
+          else
+            it { is_expected.not_to contain_concat('/etc/ferm/ferm.d/chains/nat-INPUT.conf') }
+          end
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-POSTROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/mangle-PREROUTING.conf') }
@@ -121,7 +133,11 @@ describe 'ferm' do
           it { is_expected.to contain_concat('/etc/ferm.d/chains/raw-PREROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/raw-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-PREROUTING.conf') }
-          it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-INPUT.conf') }
+          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+            it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-INPUT.conf') }
+          else
+            it { is_expected.not_to contain_concat('/etc/ferm.d/chains/nat-INPUT.conf') }
+          end
           it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-POSTROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/mangle-PREROUTING.conf') }
@@ -136,7 +152,11 @@ describe 'ferm' do
         it { is_expected.to contain_ferm__chain('raw-PREROUTING') }
         it { is_expected.to contain_ferm__chain('raw-OUTPUT') }
         it { is_expected.to contain_ferm__chain('nat-PREROUTING') }
-        it { is_expected.to contain_ferm__chain('nat-INPUT') }
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+          it { is_expected.to contain_ferm__chain('nat-INPUT') }
+        else
+          it { is_expected.not_to contain_ferm__chain('nat-INPUT') }
+        end
         it { is_expected.to contain_ferm__chain('nat-OUTPUT') }
         it { is_expected.to contain_ferm__chain('nat-POSTROUTING') }
         it { is_expected.to contain_ferm__chain('mangle-PREROUTING') }


### PR DESCRIPTION
Certain kernel modules and thus iptables functionality was introduced at
later releases, so we need to properly reflect that in our default chain
initialization procedure.

`INPUT` chain for `nat` table was introduced with 2.6.36

`ip6table_nat` kernel module for NAT functionality with IPv6 was
introduced with 3.17

This commit implements the required conditional constraints and includes
the rspec tests to validate it.