### PR TITLE
disable conntrack filtering in FORWARD/OUTPUT

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,12 +49,12 @@ class ferm::config {
   }
   ferm::chain{'FORWARD':
     policy              => $ferm::forward_policy,
-    disable_conntrack   => $ferm::disable_conntrack,
+    disable_conntrack   => true,
     log_dropped_packets => $ferm::forward_log_dropped_packets,
   }
   ferm::chain{'OUTPUT':
     policy              => $ferm::output_policy,
-    disable_conntrack   => $ferm::disable_conntrack,
+    disable_conntrack   => true,
     log_dropped_packets => $ferm::output_log_dropped_packets,
   }
 

--- a/spec/acceptance/ferm_spec.rb
+++ b/spec/acceptance/ferm_spec.rb
@@ -32,7 +32,7 @@ basic_manifest = %(
     manage_configfile => true,
     manage_initfile   => #{manage_initfile}, # CentOS-6 does not provide init script
     forward_policy    => 'DROP',
-    output_policy     => 'DROP',
+    output_policy     => 'ACCEPT',
     input_policy      => 'DROP',
     rules             => {
       'allow_acceptance_tests' => {
@@ -66,7 +66,7 @@ describe 'ferm' do
     end
 
     describe command('iptables-save') do
-      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT DROP.*}m }
+      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT ACCEPT.*}m }
     end
 
     describe iptables do


### PR DESCRIPTION
conntrack filtering basically doesn't work in those chains, so we need
to disable it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
