### PR TITLE
fix kernel incompatibilities

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,7 @@ class ferm::config {
     if versioncmp($kver, '3.17.0') >= 0 {
       # supports both nat INPUT chain and ip6table_nat
       $domains = $ferm::ip_versions
-    } elsif versioncmp($kver, '2.6.36') >= 0 {
+    } elsif versioncmp($kver, '2.6.35') >= 0 {
       # supports nat INPUT chain, but not ip6table_nat
       if ('ip6' in $ferm::ip_versions and 'ip' in $ferm::ip_versions) {
         $domains = ['ip']

--- a/spec/classes/ferm_spec.rb
+++ b/spec/classes/ferm_spec.rb
@@ -67,7 +67,7 @@ describe 'ferm' do
         it { is_expected.to contain_concat__fragment('raw-PREROUTING-config-include') }
         it { is_expected.to contain_concat__fragment('raw-OUTPUT-config-include') }
         it { is_expected.to contain_concat__fragment('nat-PREROUTING-config-include') }
-        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.35')
           it { is_expected.to contain_concat__fragment('nat-INPUT-config-include') }
         else
           it { is_expected.not_to contain_concat__fragment('nat-INPUT-config-include') }
@@ -95,7 +95,7 @@ describe 'ferm' do
         it { is_expected.to contain_concat__fragment('raw-PREROUTING-policy') }
         it { is_expected.to contain_concat__fragment('raw-OUTPUT-policy') }
         it { is_expected.to contain_concat__fragment('nat-PREROUTING-policy') }
-        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.35')
           it { is_expected.to contain_concat__fragment('nat-INPUT-policy') }
         else
           it { is_expected.not_to contain_concat__fragment('nat-INPUT-policy') }
@@ -114,7 +114,7 @@ describe 'ferm' do
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/raw-PREROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/raw-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-PREROUTING.conf') }
-          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.35')
             it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/nat-INPUT.conf') }
           else
             it { is_expected.not_to contain_concat('/etc/ferm/ferm.d/chains/nat-INPUT.conf') }
@@ -133,7 +133,7 @@ describe 'ferm' do
           it { is_expected.to contain_concat('/etc/ferm.d/chains/raw-PREROUTING.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/raw-OUTPUT.conf') }
           it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-PREROUTING.conf') }
-          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+          if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.35')
             it { is_expected.to contain_concat('/etc/ferm.d/chains/nat-INPUT.conf') }
           else
             it { is_expected.not_to contain_concat('/etc/ferm.d/chains/nat-INPUT.conf') }
@@ -152,7 +152,7 @@ describe 'ferm' do
         it { is_expected.to contain_ferm__chain('raw-PREROUTING') }
         it { is_expected.to contain_ferm__chain('raw-OUTPUT') }
         it { is_expected.to contain_ferm__chain('nat-PREROUTING') }
-        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.36')
+        if Gem::Version.new(facts[:kernelversion]) >= Gem::Version.new('2.6.35')
           it { is_expected.to contain_ferm__chain('nat-INPUT') }
         else
           it { is_expected.not_to contain_ferm__chain('nat-INPUT') }


### PR DESCRIPTION
Certain kernel modules and thus iptables functionality was introduced at
later releases, so we need to properly reflect that in our default chain
initialization procedure.

`INPUT` chain for `nat` table was introduced with 2.6.35

`ip6table_nat` kernel module for NAT functionality with IPv6 was
introduced with 3.17

This commit implements the required conditional constraints and includes
the rspec tests to validate it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
