### PR TITLE
Add support for `os.name` 'VirtuozzoLinux'

### DIFF
--- a/data/VirtuozzoLinux.yaml
+++ b/data/VirtuozzoLinux.yaml
@@ -1,0 +1,3 @@
+---
+ferm::configfile: /etc/ferm.conf
+ferm::configdirectory: /etc/ferm.d

--- a/metadata.json
+++ b/metadata.json
@@ -33,6 +33,13 @@
       ]
     },
     {
+      "operatingsystem": "VirtuozzoLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",


### PR DESCRIPTION
`facter` 3.14 adds support for `os.name` *VirtuozzoLinux* (https://puppet.com/docs/puppet/latest/release_notes_facter.html). This means `os.name` won't resolve to *RedHat* anymore.

Should *VirtuozzoLinux* be added to `metadata.json`, too?