### PR TITLE
revert PR81

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,12 +49,12 @@ class ferm::config {
   }
   ferm::chain{'FORWARD':
     policy              => $ferm::forward_policy,
-    disable_conntrack   => true,
+    disable_conntrack   => $ferm::disable_conntrack,
     log_dropped_packets => $ferm::forward_log_dropped_packets,
   }
   ferm::chain{'OUTPUT':
     policy              => $ferm::output_policy,
-    disable_conntrack   => true,
+    disable_conntrack   => $ferm::disable_conntrack,
     log_dropped_packets => $ferm::output_log_dropped_packets,
   }
 

--- a/spec/acceptance/ferm_spec.rb
+++ b/spec/acceptance/ferm_spec.rb
@@ -32,7 +32,7 @@ basic_manifest = %(
     manage_configfile => true,
     manage_initfile   => #{manage_initfile}, # CentOS-6 does not provide init script
     forward_policy    => 'DROP',
-    output_policy     => 'ACCEPT',
+    output_policy     => 'DROP',
     input_policy      => 'DROP',
     rules             => {
       'allow_acceptance_tests' => {
@@ -66,7 +66,7 @@ describe 'ferm' do
     end
 
     describe command('iptables-save') do
-      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT ACCEPT.*}m }
+      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT DROP.*}m }
     end
 
     describe iptables do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The PR #81 disable conntrack on `OUTPUT`.
With `output_policy` to `DROP` value, upgrading to `puppet-ferm` 2.6.0 block network access to nodes.

This change was not backward compatible.
* step 1 release a 2.7.0 without breaking change. Because upgrading from 2.x to last 2.x is expected to break nothing
* step 2 release a 3.0.0 with PR81 re added.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
