### PR TITLE
use dedicated conntrack parameters / by default disable conntrack for new chains /  by default enable conntrack for filter INPUT chain

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -112,11 +112,27 @@ Data type: `Stdlib::Absolutepath`
 
 Path to the directory where the module stores ferm configuration files
 
-##### `disable_conntrack`
+##### `forward_disable_conntrack`
 
 Data type: `Boolean`
 
-Disable/Enable the generation of conntrack rules
+Enable/Disable the generation of conntrack rules for the FORWARD chain
+
+Default value: `true`
+
+##### `output_disable_conntrack`
+
+Data type: `Boolean`
+
+Enable/Disable the generation of conntrack rules for the OUTPUT chain
+
+Default value: `true`
+
+##### `input_disable_conntrack`
+
+Data type: `Boolean`
+
+Enable/Disable the generation of conntrack rules for the INPUT chain
 
 Default value: `false`
 
@@ -227,7 +243,9 @@ The following parameters are available in the `ferm::chain` defined type.
 
 Data type: `Boolean`
 
-Disable/Enable usage of conntrack
+Disable/Enable usage of conntrack. By default, we enable conntrack only for the filter INPUT chain
+
+Default value: `true`
 
 ##### `log_dropped_packets`
 

--- a/manifests/chain.pp
+++ b/manifests/chain.pp
@@ -7,7 +7,7 @@
 #     log_dropped_packets => true,
 #   }
 #
-# @param disable_conntrack Disable/Enable usage of conntrack
+# @param disable_conntrack Disable/Enable usage of conntrack. By default, we enable conntrack only for the filter INPUT chain
 # @param log_dropped_packets Enable/Disable logging of packets to the kernel log, if no explicit chain matched
 # @param policy Set the default policy for CHAIN (works only for builtin chains)
 #   Allowed values: (ACCEPT|DROP) (see Ferm::Policies type)
@@ -18,8 +18,8 @@
 # @param ip_versions Set list of versions of ip we want ot use.
 #
 define ferm::chain (
-  Boolean $disable_conntrack,
   Boolean $log_dropped_packets,
+  Boolean $disable_conntrack           = true,
   String[1] $chain                     = $name,
   Optional[Ferm::Policies] $policy     = undef,
   Ferm::Tables $table                  = 'filter',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,17 +47,17 @@ class ferm::config {
 
   ferm::chain{'INPUT':
     policy              => $ferm::input_policy,
-    disable_conntrack   => $ferm::disable_conntrack,
+    disable_conntrack   => $ferm::input_disable_conntrack,
     log_dropped_packets => $ferm::input_log_dropped_packets,
   }
   ferm::chain{'FORWARD':
     policy              => $ferm::forward_policy,
-    disable_conntrack   => $ferm::disable_conntrack,
+    disable_conntrack   => $ferm::forward_disable_conntrack,
     log_dropped_packets => $ferm::forward_log_dropped_packets,
   }
   ferm::chain{'OUTPUT':
     policy              => $ferm::output_policy,
-    disable_conntrack   => $ferm::disable_conntrack,
+    disable_conntrack   => $ferm::output_disable_conntrack,
     log_dropped_packets => $ferm::output_log_dropped_packets,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,9 @@
 # @param manage_initfile Disable/Enable the management of the ferm init script for RedHat-based OS
 # @param configfile Path to the config file
 # @param configdirectory Path to the directory where the module stores ferm configuration files
-# @param disable_conntrack Disable/Enable the generation of conntrack rules
+# @param forward_disable_conntrack Enable/Disable the generation of conntrack rules for the FORWARD chain
+# @param output_disable_conntrack Enable/Disable the generation of conntrack rules for the OUTPUT chain
+# @param input_disable_conntrack Enable/Disable the generation of conntrack rules for the INPUT chain
 # @param forward_policy Default policy for the FORWARD chain
 # @param output_policy Default policy for the OUTPUT chain
 # @param input_policy Default policy for the INPUT chain
@@ -50,7 +52,9 @@ class ferm (
   Boolean $manage_service = false,
   Boolean $manage_configfile = false,
   Boolean $manage_initfile = false,
-  Boolean $disable_conntrack = false,
+  Boolean $forward_disable_conntrack = true,
+  Boolean $output_disable_conntrack = true,
+  Boolean $input_disable_conntrack = false,
   Ferm::Policies $forward_policy = 'DROP',
   Ferm::Policies $output_policy = 'ACCEPT',
   Ferm::Policies $input_policy = 'DROP',

--- a/spec/acceptance/ferm_spec.rb
+++ b/spec/acceptance/ferm_spec.rb
@@ -32,7 +32,7 @@ basic_manifest = %(
     manage_configfile => true,
     manage_initfile   => #{manage_initfile}, # CentOS-6 does not provide init script
     forward_policy    => 'DROP',
-    output_policy     => 'DROP',
+    output_policy     => 'ACCEPT',
     input_policy      => 'DROP',
     rules             => {
       'allow_acceptance_tests' => {
@@ -66,7 +66,7 @@ describe 'ferm' do
     end
 
     describe command('iptables-save') do
-      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT DROP.*}m }
+      its(:stdout) { is_expected.to match %r{.*filter.*:INPUT DROP.*:FORWARD DROP.*:OUTPUT ACCEPT.*}m }
     end
 
     describe iptables do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This tries to reintroduce what was done in #81 in a way more customizable. This  
permits to have default policy to DROP with OUTPUT chain.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
