### PR TITLE
Allow adding custom ferm dsl for subchains. This is important for usi…

### DIFF
--- a/spec/defines/chain_spec.rb
+++ b/spec/defines/chain_spec.rb
@@ -70,6 +70,34 @@ describe 'ferm::chain', type: :define do
 
         it { is_expected.to compile.and_raise_error(%r{Can only set a default policy for builtin chains}) }
       end
+
+      context 'with custom chain FERM-DSL using content parameter' do
+        let(:title) { 'FERM-DSL' }
+        let :params do
+          {
+            content: 'mod rpfilter invert DROP;'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('filter-FERM-DSL-config-include') }
+        it do
+          is_expected.to contain_concat__fragment('filter-FERM-DSL-custom-content'). \
+            with_content(%r{mod rpfilter invert DROP;})
+        end
+        it do
+          is_expected.not_to contain_concat__fragment('filter-FERM-DSL-policy')
+        end
+        it do
+          is_expected.not_to contain_concat__fragment('filter-FERM-DSL-footer')
+        end
+        if facts[:os]['name'] == 'Debian'
+          it { is_expected.to contain_concat('/etc/ferm/ferm.d/chains/filter-FERM-DSL.conf') }
+        else
+          it { is_expected.to contain_concat('/etc/ferm.d/chains/filter-FERM-DSL.conf') }
+        end
+        it { is_expected.to contain_ferm__chain('FERM-DSL') }
+      end
     end
   end
 end

--- a/templates/ferm_chain_custom.conf.epp
+++ b/templates/ferm_chain_custom.conf.epp
@@ -1,0 +1,4 @@
+<%- | String[1] $content,
+| -%>
+# THIS FILE IS MANAGED BY PUPPET
+<%= $content %>


### PR DESCRIPTION
…ng complex iptable rules that are currently not supported by this module or would be very hard to manage just using puppet.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Allows adding custom ferm dsl for subchains. This is important for using complex iptable rules that are currently not supported by this module or would be very hard to manage just using puppet.

I am using this to manage the OpenVPN router subchain. I have provide a simple example use case in the REFERENCE.md. 

#### This Pull Request (PR) fixes the following issues
Fixes #76
