### PR TITLE
Add missing os key in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - bundle --version
 script:
   - 'bundle exec rake $CHECK'
-matrix:
+jobs:
   fast_finish: true
   include:
   - rvm: 2.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+os: linux
 dist: bionic
 language: ruby
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
-  user: puppet
+  username: puppet
   password:
     secure: "J7AG0AHVdEVql4c7cwJZCjbXFp5tehPnlS3REkUKu9s3Px+XRb+073W7hM2alfxB5Qo3mqyMdgyjIRMQyXXqfb54QmDG6Y1XfRIcNK/C6TL9JscC7rXN1gXJhrdZiQOtfXa3HFcWJkbsQrjnPbQ5y+ b5VdkzIthLkIa4IpQEYSQC5i88nDixF8dgApLGgC0CcmS+14iXZgJ2T89A7QiSbvhnIsszaIQucw91/Kled9mUT2cJlFrMXLfd3hycR/ftLJeBe6MvnlaflSqEWfz9UA7EW63JX13hhyNNaf26JsFyG7P7UiH6+dBGXX3xLPKeq032VysZzbmA1GFZYiGk0obAtqMlrfbcpsLceyg1FCku2/lv/6P9dkfjN0N0z7pgL0lGjjhN3lNwU997fIXq/tt3dxbXKFV2Ok16p/55VjV5i2U79bNTn6oZpqLzB6ZEc9WOb3DvBsLP5ooThSVtrZecTFZbjRFAT/Vd0nd/qIzdxEoaVVaSPOpaZf6v1Ojy3RMzSSOUdweDBNh0B+9p0tVDpiLhRYpAFbw1JH2X0dlPqtrKS+BNU8xwktfK5KGpvvfXdU+pWUKxP1MnzrmX5jDX3dIh7pkGRvaKSD5RTmufCVaR0neEBV3VERPPYLDKueGc3BgWtVqaEyZwuM5AMJJuWKkTIQsUPsXKbIqyP5c="
   on:


### PR DESCRIPTION
without this, the travis linter tells us the following warning:

```
root: missing os, using the default linux
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
