### PR TITLE
Add ferm::rule parameters `outerface`, `to_source` and `to_destination`.

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -84,8 +84,8 @@ define ferm::rule (
     fail('Exactly one of "action" or the deprecated "policy" param is required.')
   }
 
-  if $action_temp == 'SNAT' and ($chain != 'POSTROUTING' or $table != 'nat') {
-    fail('"SNAT" is only valid in the "POSTROUTING" chain of the "nat" table.')
+  if $action_temp == 'SNAT' and !($chain in ['POSTROUTING', 'INPUT'] and $table == 'nat') {
+    fail('"SNAT" is only valid in the "POSTROUTING" and "INPUT" chains of the "nat" table.')
   }
 
   if $outerface and !($chain in ['FORWARD', 'OUTPUT', 'POSTROUTING']) {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add options:
* `outerface` (iptables `--out-interface`)
* `to_source` (iptables `--to-source`)
* `to_destination` (iptables `--to-destination`)

#### This Pull Request (PR) fixes the following issues
Fixes #74 
