### PR TITLE
Drop Fedora 26, add Fedora 32

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "26"
+        "32"
       ]
     },
     {


### PR DESCRIPTION
Included in https://github.com/voxpupuli/puppet-ferm/pull/119, here for the changelog.