### PR TITLE
Allow numeric values as protocol references

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -89,8 +89,9 @@ define ferm::rule (
   }
 
   $proto_real = $proto ? {
-    Array  => "proto (${join($proto, ' ')})",
-    String => "proto ${proto}",
+    Array   => "proto (${join($proto, ' ')})",
+    String  => "proto ${proto}",
+    Integer => "proto ${proto}",
   }
 
   if $dport =~ Array {

--- a/spec/type_aliases/protocols_spec.rb
+++ b/spec/type_aliases/protocols_spec.rb
@@ -15,6 +15,8 @@ describe 'Ferm::Protocols' do
       'mh',
       'all',
       ['icmp', 'tcp', 'udp'],
+      0,
+      [0, 4],
     ].each do |value|
       describe value.inspect do
         it { is_expected.to allow_value(value) }
@@ -36,6 +38,8 @@ describe 'Ferm::Protocols' do
         [95_000, 67_000],
         {},
         { 'foo' => 'bar' },
+        256,
+        ['icmp', 256],
       ].each do |value|
         describe value.inspect do
           it { is_expected.not_to allow_value(value) }

--- a/types/protocols.pp
+++ b/types/protocols.pp
@@ -1,5 +1,7 @@
 # @summary a list of allowed protocolls to match
 type Ferm::Protocols = Variant[
+  Integer[0, 255],
+  Array[Integer[0, 255]],
   Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all'],
   Array[Enum['icmp', 'tcp', 'udp', 'udplite', 'icmpv6', 'esp', 'ah', 'sctp', 'mh', 'all']],
 ]


### PR DESCRIPTION
'iptables' itself allows protocols to be referenced by numeric values. This patch extends 'Ferm::Protocols' to match integer values between 0 and 255.

> The specified protocol can be one of tcp, udp, udplite, icmp, icmpv6,esp,
> ah, sctp, mh or the special keyword "all", or it can be a numeric value,
> representing one of these protocols or a different one.
source: https://ipset.netfilter.org/iptables.man.html

Also see [0] for Assigned Internet Protocol Numbers.

--
[0] https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml