### PR TITLE
Drop Fedora support (they dont support ferm anymore)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,12 +49,6 @@
       ]
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "26"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9",


### PR DESCRIPTION
current  maintained fedora versions are 32 and newer. they don't support ferm anymore: https://src.fedoraproject.org/rpms/ferm