### PR TITLE
Exec: Adjust PATH during ferm installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,7 @@ class ferm::install {
       }
       -> exec { 'make install':
         cwd     => $_source_path,
-        path    => '/usr/sbin:/usr/bin:/sbin:/bin',
+        path    => '/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/core_perl',
         creates => '/usr/sbin/ferm',
       }
       -> file { '/etc/ferm':


### PR DESCRIPTION
some perl deps can be in a different PATH.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
