### PR TITLE
Enable negation of 'saddr', 'daddr', 'sport', and 'dport'

### DIFF
--- a/types/negation.pp
+++ b/types/negation.pp
@@ -1,0 +1,5 @@
+# @summary list of keywords that support negation
+type Ferm::Negation = Variant[
+  Enum['saddr', 'daddr', 'sport', 'dport'],
+  Array[Enum['saddr', 'daddr', 'sport', 'dport']],
+]


### PR DESCRIPTION
I successfully tested negation with 'saddr', 'daddr', 'sport', and 'dport' using ferm v2.6.

The new parameter `negate` takes String as well as Array.

```
'forward_accept_rfc1918':
  chain: 'DOCKER-USER'
  action: 'ACCEPT'
  proto: 'tcp'
  saddr:
    - '10.0.0.0/8'
  negate: 'saddr'
```  
  
```
'forward_accept_rfc1918':
  chain: 'DOCKER-USER'
  action: 'ACCEPT'
  proto: 'tcp'
  saddr:
    - '10.0.0.0/8'
  negate:
    - 'saddr'
```