### PR TITLE
ensure correct ordering of concat::fragments

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -188,21 +188,21 @@ define ferm::rule (
         concat::fragment { "${chain}-${interface}-aaa":
           target  => $filename,
           content => "interface ${interface} {\n",
-          order   => $interface,
+          order   => "${interface}-000",
         }
       }
 
       concat::fragment { "${chain}-${interface}-${name}":
         target  => $filename,
         content => "  ${rule}\n",
-        order   => $interface,
+        order   => "${interface}-001",
       }
 
       unless defined(Concat::Fragment["${chain}-${interface}-zzz"]) {
         concat::fragment { "${chain}-${interface}-zzz":
           target  => $filename,
           content => "}\n",
-          order   => $interface,
+          order   => "${interface}-999",
         }
       }
     } else {


### PR DESCRIPTION
> Fragments that share the same order number are ordered by name.
```
"${chain}-${interface}-aaa"
"${chain}-${interface}-${name}"
"${chain}-${interface}-zzz"
```

If `name` starts with upper case letter they're placed outside of `interface eth0 {}`:

```
  mod comment comment 'AAA-minimal_example' proto all ACCEPT;
interface eth0 {
  mod comment comment 'aaa-minimal_example:' proto all ACCEPT;
  mod comment comment 'minimal_example' proto all ACCEPT;
}
```

I looked into testing for correct ordering, but didn't find a working solution.

There is (e.g.) [`.that_comes_before`](https://rspec-puppet.com/documentation/classes/#testing-relationships-between-resources), but that's testing against `before => ...`.

I also unsuccessfully tried testing against the content of `File[/etc/ferm.d/chains/INPUT.conf]` generated by `concat_file`.