### PR TITLE
Drop EL support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,7 +33,7 @@ class ferm::config {
 
   if $ferm::manage_configfile {
     concat { $ferm::configfile:
-      ensure  => 'present',
+      ensure => 'present',
     }
     concat::fragment { 'ferm_header.conf':
       target  => $ferm::configfile,

--- a/metadata.json
+++ b/metadata.json
@@ -27,18 +27,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04",


### PR DESCRIPTION
Drop EL support as ferm has no official package for CentOS 9 (at least to my knowledge). CentOS 7 and 8 are EOL.