### PR TITLE
Drop Debian 10 support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,7 +33,7 @@ class ferm::config {
 
   if $ferm::manage_configfile {
     concat { $ferm::configfile:
-      ensure  => 'present',
+      ensure => 'present',
     }
     concat::fragment { 'ferm_header.conf':
       target  => $ferm::configfile,

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },


### PR DESCRIPTION
As debian 10 went EOL in June 2024, we should also drop support here